### PR TITLE
fix: resolve NameError and add ARM64 support

### DIFF
--- a/main.py
+++ b/main.py
@@ -784,6 +784,7 @@ if __name__ == '__main__':
     
     # load proxies from file
     result = WebDriverInstaller(GOOGLE_CHROME).detect_installed_browser()
+    browser_name = None
     if result is not None:
         browser_name = result[0]
     if browser_name == GOOGLE_CHROME and os.path.exists(args['proxy_file']) and os.path.isfile(args['proxy_file']):

--- a/modules/SharedTools.py
+++ b/modules/SharedTools.py
@@ -273,6 +273,12 @@ def dataGenerator(length, only_numbers=False):
 def initSeleniumWebDriver(browser_name: str, webdriver_path = None, browser_path = '', chrome_proxy_extension_path = '', headless=True):
     if browser_path is None:
         browser_path = ''
+    import platform, os
+    if platform.machine() == 'aarch64' and browser_name == GOOGLE_CHROME:
+        if not webdriver_path and os.path.exists('/usr/bin/chromedriver'):
+            webdriver_path = '/usr/bin/chromedriver'
+        if not browser_path and os.path.exists('/usr/bin/chromium'):
+            browser_path = '/usr/bin/chromium'
     logging.info('-- Browsers Initializer --')
     console_log(f'{colorama.Fore.LIGHTMAGENTA_EX}-- Browsers Initializer --{colorama.Fore.RESET}\n', silent_mode=SILENT_MODE)
     if os.name == 'posix': # For Linux

--- a/modules/WebDriverInstaller.py
+++ b/modules/WebDriverInstaller.py
@@ -390,6 +390,9 @@ class WebDriverInstaller(object):
                         return None
             
     def menu(self, disable_progress_bar=False): # auto updating or installing webdrivers
+        import platform
+        if platform.machine() == 'aarch64':
+            return ['/usr/bin/chromedriver', '/usr/bin/chromium']
         def download():
             driver_url = self.browser_data[0]()
             if driver_url is not None:


### PR DESCRIPTION
## Summary
This PR addresses two bugs encountered when running the project, particularly on ARM64 (aarch64) environments.

### 1. Fix `NameError` in `main.py`
When `detect_installed_browser()` returns `None` (e.g., when the system hasn't installed the browser yet), the variable `browser_name` is left unassigned, leading to a `NameError` on the next line.
**Fix**: Initialized `browser_name = None` before the `if result is not None:` check.

### 2. Support for ARM64 (`aarch64`) architecture
`selenium-manager` currently does not support automatically downloading Chrome/ChromeDriver for the `linux/aarch64` platform, leading to an `Unsupported platform/architecture combination: linux/aarch64` error.
**Fix**: Added a check for `platform.machine() == 'aarch64'`. If detected, it bypasses the download and returns the system's default chromium and chromedriver paths (`/usr/bin/chromedriver` and `/usr/bin/chromium`). This allows users on ARM64 (like Raspberry Pi or ARM VMs) to run the script successfully after running `apt-get install -y chromium chromium-driver`.

*Note: This PR was created automatically based on user-provided fixes.*